### PR TITLE
Add reader.reload() method that calls dnstable_reader_reload_setfile()

### DIFF
--- a/dnstable.pxi
+++ b/dnstable.pxi
@@ -61,6 +61,7 @@ cdef extern from "dnstable.h":
 
     # reader
     dnstable_reader * dnstable_reader_init_setfile(char *)
+    void dnstable_reader_reload_setfile(dnstable_reader *)
     void dnstable_reader_destroy(dnstable_reader **)
     dnstable_iter * dnstable_reader_iter(dnstable_reader *)
     dnstable_iter * dnstable_reader_query(dnstable_reader *, dnstable_query *)

--- a/dnstable.pyx
+++ b/dnstable.pyx
@@ -231,6 +231,9 @@ cdef class reader(object):
         self._instance = dnstable_reader_init_setfile(PyString_AsString(fname))
         self.iszone = iszone
 
+    def reload(self):
+        dnstable_reader_reload_setfile(self._instance)
+
     def query(self, query q):
         it = iteritems(self.iszone)
         it._instance = dnstable_reader_query(self._instance, q._instance)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
     setup(
         name = NAME,
         version = VERSION,
-        ext_modules = [ Extension('dnstable', ['dnstable.pyx'], **pkgconfig('libdnstable >= 0.7.0')) ],
+        ext_modules = [ Extension('dnstable', ['dnstable.pyx'], **pkgconfig('libdnstable >= 0.8.0')) ],
         cmdclass = {'build_ext': build_ext},
     )
 except ImportError:
@@ -35,7 +35,7 @@ except ImportError:
         setup(
             name = NAME,
             version = VERSION,
-            ext_modules = [ Extension('dnstable', ['dnstable.c'], **pkgconfig('libdnstable >= 0.7.0')) ],
+            ext_modules = [ Extension('dnstable', ['dnstable.c'], **pkgconfig('libdnstable >= 0.8.0')) ],
         )
     else:
         raise


### PR DESCRIPTION
This introduces support for the dnstable_reader_reload_setfile()
function, which checks the underlying setfile for changes and reloads
the dnstable_reader object.

The C function will be introduced in dnstable 0.8.0, so bump the
pkg-config versioned dependency on libdnstable.