### PR TITLE
prep for 0.6.1 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pydnstable (0.6.1-1) debian-farsightsec; urgency=medium
+
+  * Fix bug with negative epoch times. Add try/except around time
+    conversions from signed python integers.
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Mon, 15 Oct 2018 11:32:58 -0400
+
 pydnstable (0.6.0-1) wheezy-farsightsec; urgency=medium
 
   * New upstream release.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 NAME = 'pydnstable'
-VERSION = '0.6.0'
+VERSION = '0.6.1'
 
 from distutils.core import setup
 from distutils.extension import Extension


### PR DESCRIPTION
Release is for one bug fix for handling invalid epoch times.