### PR TITLE
Add aggregate parameter to query class init function.  

### DIFF
--- a/dnstable.pxi
+++ b/dnstable.pxi
@@ -1,5 +1,5 @@
 cimport cython
-from cpython cimport bool
+from libcpp cimport bool
 from cpython.string cimport *
 from libc.stddef cimport *
 from libc.stdint cimport *
@@ -70,6 +70,8 @@ cdef extern from "dnstable.h":
     char * dnstable_query_get_error(dnstable_query *)
     dnstable_res dnstable_query_set_data(dnstable_query *, char *)
     dnstable_res dnstable_query_set_rrtype(dnstable_query *, char *)
+    dnstable_res dnstable_query_set_aggregated(dnstable_query *, bool)
+    bool dnstable_query_is_aggregated(const dnstable_query *)
     dnstable_res dnstable_query_set_bailiwick(dnstable_query *, char *)
     dnstable_res dnstable_query_set_timeout(dnstable_query *, timespec *)
     dnstable_res dnstable_query_set_filter_parameter(dnstable_query *, dnstable_filter_parameter_type, void *, size_t)

--- a/dnstable.pyx
+++ b/dnstable.pyx
@@ -176,7 +176,7 @@ cdef class query(object):
     def __cinit__(self):
         self._instance = NULL
 
-    def __init__(self, qtype, str data, str rrtype=None, str bailiwick=None, time_first_before=None, time_first_after=None, time_last_before=None, time_last_after=None, timeout=None):
+    def __init__(self, qtype, str data, str rrtype=None, str bailiwick=None, time_first_before=None, time_first_after=None, time_last_before=None, time_last_after=None, timeout=None, aggregate=True):
         cdef dnstable_res
         cdef timespec ts
         cdef uint64_t tm
@@ -198,6 +198,10 @@ cdef class query(object):
             res = dnstable_query_set_rrtype(self._instance, PyString_AsString(rrtype))
             if res != dnstable_res_success:
                 raise DnstableException, 'dnstable_query_set_rrtype() failed: %s' % dnstable_query_get_error(self._instance)
+
+        res = dnstable_query_set_aggregated(self._instance, aggregate)
+        if res != dnstable_res_success:
+            raise DnstableException, 'dnstable_query_set_aggregated() failed: %s' % dnstable_query_get_error(self._instance)
 
         if qtype == RRSET and bailiwick:
             res = dnstable_query_set_bailiwick(self._instance, PyString_AsString(bailiwick))
@@ -298,6 +302,7 @@ cdef class reader(object):
 
     def query(self, query q):
         it = iteritems(self.iszone)
+
         it._instance = dnstable_reader_query(self._instance, q._instance)
         it.q = q
         return it


### PR DESCRIPTION
Call dnstable_reader_query_no_aggregate when it is set to false