### PR TITLE
fix: memory corruption due to live query obj refd from freed iter obj

### DIFF
--- a/dnstable.pyx
+++ b/dnstable.pyx
@@ -170,7 +170,6 @@ cdef class entry(object):
 cdef class iteritems(object):
     cdef dnstable_iter *_instance
     cdef object iszone
-    cdef object q
 
     def __cinit__(self):
         self._instance = NULL
@@ -345,5 +344,4 @@ cdef class reader(object):
         it = iteritems(self.iszone)
 
         it._instance = dnstable_reader_query(self._instance, q._instance)
-        it.q = q
         return it


### PR DESCRIPTION
the 'q' ref (in iteritems) is never used and so unneeded. additionally, it causes eventual memory corruption if the module is exercised enough due to iteritems being freed but not q. the following should manifest the bug (segv). since 'q' is not used, the fix is to remove it.

```
import dnstable as dt

rdr = dt.reader("/your/fileset")

for i in range(1, 254):
    print(f"******** 8.8.8.{i}")
    q = dt.query(dt.RDATA_IP, f"8.8.8.{i}")
    try:
        rv = rdr.query(q)
        for r in rv:
            print(r)
    except Exception as e:
        print(f"failed: {e}")
```
