### PR TITLE
Fix build with cython 3.X

### DIFF
--- a/dnstable.pxi
+++ b/dnstable.pxi
@@ -16,7 +16,6 @@
 
 cimport cython
 from libcpp cimport bool
-from cpython.string cimport *
 from libc.stddef cimport *
 from libc.stdint cimport *
 from libc.stdlib cimport *


### PR DESCRIPTION
Allow building with cython 3.X, while mantaining compatibility with cython 0.3.